### PR TITLE
workaround for undefined ENOATTR compiler error in get_all()

### DIFF
--- a/xattr.c
+++ b/xattr.c
@@ -97,6 +97,11 @@ typedef int Py_ssize_t;
    multi-operations */
 #define ESTIMATE_ATTR_SIZE 256
 
+/* workaround for compiler error in get_all() for undefined ENOATTR */
+#ifundef ENOATTR
+#define  ENOATTR ENODATA
+#endif
+
 typedef enum {T_FD, T_PATH, T_LINK} target_e;
 
 typedef struct {


### PR DESCRIPTION
gcc on Fedora 28 throws this error